### PR TITLE
update docs for external secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,10 +112,8 @@ Option 2: Allow the external-secret application to assume roles that have more n
 - Placeholder:        `<<__role_arn.external_secrets>>`
 - Example ARN:        `arn:aws:iam::123456789012:role/my-cluster_kube-system_external_secrets`
 - Policy:             
-  - [Option 1](./docs/iam_policies/external-secrets.json)
-  - Option 2 requires only a trust relationship. See below
-
-In the second case, you then need to define roles to be assumed by the ExternalSecret resources that will be created. Each of these roles will need to have the follow trust relationship to the external-secrets role:
+  - [Option 1](./docs/iam_policies/external-secrets-option-1.json)
+  - [Option 2](./docs/iam_policies/external-secrets-option-2.json). In addition, for this case you then need to define roles to be assumed by the ExternalSecret resources that will be created. Each of these roles will need to have the follow trust relationship to the external-secrets role:
 
 ```json
 {
@@ -125,7 +123,7 @@ In the second case, you then need to define roles to be assumed by the ExternalS
       "Sid": "",
       "Effect": "Allow",
       "Principal": {
-        "AWS": "arn:aws:iam::123456789012:role/dev-kf13-14_kube-system_external-secrets"
+        "AWS": "arn:aws:iam::123456789012:role/my-cluster_kube-system_external-secrets"
       },
       "Action": "sts:AssumeRole"
     }

--- a/docs/iam_policies/cluster-autoscaler.json
+++ b/docs/iam_policies/cluster-autoscaler.json
@@ -27,7 +27,7 @@
                     "autoscaling:ResourceTag/k8s.io/cluster-autoscaler/enabled": [
                         "true"
                     ],
-                    "autoscaling:ResourceTag/kubernetes.io/cluster/dev-kf13-14": [
+                    "autoscaling:ResourceTag/kubernetes.io/cluster/my-cluster": [
                         "owned"
                     ]
                 }

--- a/docs/iam_policies/external-secrets-option-1.json
+++ b/docs/iam_policies/external-secrets-option-1.json
@@ -10,7 +10,7 @@
                 "secretsmanager:GetResourcePolicy",
                 "secretsmanager:DescribeSecret"
             ],
-            "Resource": "arn:aws:secretsmanager:eu-central-1:123456789012:secret:dev-kf13-14*"
+            "Resource": "arn:aws:secretsmanager:eu-central-1:123456789012:secret:my-cluster*"
         }
     ]
 }

--- a/docs/iam_policies/external-secrets-option-2.json
+++ b/docs/iam_policies/external-secrets-option-2.json
@@ -1,0 +1,11 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "",
+            "Effect": "Allow",
+            "Action": "sts:AssumeRole",
+            "Resource": "arn:aws:iam::123456789012:role/my-cluster_external_secret*"
+        }
+    ]
+}

--- a/docs/iam_policies/external-secrets_argocd.json
+++ b/docs/iam_policies/external-secrets_argocd.json
@@ -9,7 +9,7 @@
                 "secretsmanager:GetResourcePolicy",
                 "secretsmanager:DescribeSecret"
             ],
-            "Resource": "arn:aws:secretsmanager:eu-central-1:123456789012:secret:dev-kf13-14/argocd*"
+            "Resource": "arn:aws:secretsmanager:eu-central-1:123456789012:secret:my-cluster/argocd*"
         }
     ]
 }

--- a/docs/iam_policies/external-secrets_kubeflow.json
+++ b/docs/iam_policies/external-secrets_kubeflow.json
@@ -9,7 +9,7 @@
                 "secretsmanager:GetResourcePolicy",
                 "secretsmanager:DescribeSecret"
             ],
-            "Resource": "arn:aws:secretsmanager:eu-central-1:123456789012:secret:dev-kf13-14/kubeflow*"
+            "Resource": "arn:aws:secretsmanager:eu-central-1:123456789012:secret:my-cluster/kubeflow*"
         }
     ]
 }

--- a/docs/iam_policies/external-secrets_mlflow.json
+++ b/docs/iam_policies/external-secrets_mlflow.json
@@ -9,7 +9,7 @@
                 "secretsmanager:GetResourcePolicy",
                 "secretsmanager:DescribeSecret"
             ],
-            "Resource": "arn:aws:secretsmanager:eu-central-1:123456789012:secret:dev-kf13-14/mlflow*"
+            "Resource": "arn:aws:secretsmanager:eu-central-1:123456789012:secret:my-cluster/mlflow*"
         }
     ]
 }

--- a/docs/iam_policies/external-secrets_oauth2-proxy.json
+++ b/docs/iam_policies/external-secrets_oauth2-proxy.json
@@ -9,7 +9,7 @@
                 "secretsmanager:GetResourcePolicy",
                 "secretsmanager:DescribeSecret"
             ],
-            "Resource": "arn:aws:secretsmanager:eu-central-1:123456789012:secret:dev-kf13-14/oauth2-proxy*"
+            "Resource": "arn:aws:secretsmanager:eu-central-1:123456789012:secret:my-cluster/oauth2-proxy*"
         }
     ]
 }


### PR DESCRIPTION
makes cluster name generic, and adds the correct policy for "Option 2"