### PR TITLE
Add scope and user-id-claim extra args

### DIFF
--- a/distribution/oidc-auth/base/oauth2-proxy.yaml
+++ b/distribution/oidc-auth/base/oauth2-proxy.yaml
@@ -45,6 +45,10 @@ spec:
         value: .<<__domain__>>
       - name: extraArgs.oidc-issuer-url
         value: <<__oidc.issuer__>>
+      - name: extraArgs.scope
+        value: <<__oidc.scope__>>
+      - name: extraArgs.user-id-claim
+        value: <<__oidc.user_id_claim__>>
       - name: serviceAccount.enabled
         value: 'false'   # we will create the ServiceAccount manually.
       - name: serviceAccount.name

--- a/examples/setup.conf
+++ b/examples/setup.conf
@@ -66,3 +66,6 @@
 <<__aws_load_balancer.nlb_target_type__>>=instance
 <<__oidc.issuer__>>=https://gitlab.my-company.com
 <<__oidc.redis.connection_url__>>=redis://my-cluster-redis.abcxyz.0001.euc1.cache.amazonaws.com:6379
+<<__oidc.scope__>>=openid profile email
+<<__oidc.user_id_claim__>>=email
+


### PR DESCRIPTION
This PR adds additional arguments to oauth2-proxy for scope and user-id-claim. These are needed in particular because the default values do not appear to work with Azure AD, and so they need to be configurable.