### PR TITLE
Add support for configurable ExternalSecrets backendType

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,13 @@ In addition, we need to grant each role limited access to secrets. We have chose
 - Policy:             [link](./docs/iam_policies/external-secrets_mlflow.json)
 
 
+#### Backend types
 
+There are two supported AWS backend types:
+- [Secrets Manager](https://aws.amazon.com/secrets-manager/) is the default type set in [setup.conf](./examples/setup.conf).
+  - `<<__external_secrets.backend_type__>>=secretsManager`
+- [System Manager](https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-parameter-store.html) can be used instead by updating the following placeholder value in [setup.conf](./examples/setup.conf) to `systemManager`.
+  - `<<__external_secrets.backend_type__>>=systemManager`
 ---
 # AWS Users
 

--- a/distribution/argocd/overlays/private-repo/secret.yaml
+++ b/distribution/argocd/overlays/private-repo/secret.yaml
@@ -4,7 +4,7 @@ metadata:
   name: git-repo-secret
   namespace: argocd
 spec:
-  backendType: secretsManager
+  backendType: <<__external_secrets.backend_type__>>
   roleArn: <<__role_arn.external_secrets.argocd__>>
   data:
   - key: <<__external_secret_name.git_repo.https_username__>>

--- a/distribution/certificates/overlays/imported/auth-certificate-secret.yaml
+++ b/distribution/certificates/overlays/imported/auth-certificate-secret.yaml
@@ -4,7 +4,7 @@ metadata:
   name: auth-ingressgateway-certs
   namespace: istio-system
 spec:
-  backendType: secretsManager
+  backendType: <<__external_secrets.backend_type__>>
   template:
     type: kubernetes.io/tls
   roleArn: <<__role_arn.external_secrets.istio_system__>>

--- a/distribution/certificates/overlays/imported/kubeflow-gateway-cert-secret.yaml
+++ b/distribution/certificates/overlays/imported/kubeflow-gateway-cert-secret.yaml
@@ -4,7 +4,7 @@ metadata:
   name: kubeflow-ingressgateway-certs
   namespace: istio-system
 spec:
-  backendType: secretsManager
+  backendType: <<__external_secrets.backend_type__>>
   template:
     type: kubernetes.io/tls
   roleArn: <<__role_arn.external_secrets.istio_system__>>

--- a/distribution/certificates/overlays/imported/monitoring-certificate-secret.yaml
+++ b/distribution/certificates/overlays/imported/monitoring-certificate-secret.yaml
@@ -4,7 +4,7 @@ metadata:
   name: monitoring-ingressgateway-certs
   namespace: istio-system
 spec:
-  backendType: secretsManager
+  backendType: <<__external_secrets.backend_type__>>
   template:
     type: kubernetes.io/tls
   roleArn: <<__role_arn.external_secrets.istio_system__>>

--- a/distribution/kubeflow/katib/rds-secret.yaml
+++ b/distribution/kubeflow/katib/rds-secret.yaml
@@ -4,7 +4,7 @@ metadata:
   name: katib-rds-secret
   namespace: kubeflow
 spec:
-  backendType: secretsManager
+  backendType: <<__external_secrets.backend_type__>>
   roleArn: <<__role_arn.external_secrets.kubeflow__>>
   data:
   - key: <<__external_secret_name.kubeflow.rds_username__>>

--- a/distribution/kubeflow/pipelines/base/patches/kubeflow-pipelines-profile-controller.yaml
+++ b/distribution/kubeflow/pipelines/base/patches/kubeflow-pipelines-profile-controller.yaml
@@ -19,6 +19,8 @@ spec:
           value: <<__external_secret_name.kubeflow.s3_secretkey__>>
         - name: EXTERNAL_SECRET_ROLE_ARN
           value: <<__role_arn.external_secrets.kubeflow__>>
+        - name: EXTERNAL_SECRET_BACKEND_TYPE
+          value: <<__external_secrets.backend_type__>>
 
         # remove minio-related params
         - $patch: delete

--- a/distribution/kubeflow/pipelines/base/patches/sync_with_s3.py
+++ b/distribution/kubeflow/pipelines/base/patches/sync_with_s3.py
@@ -22,6 +22,7 @@ disable_istio_sidecar = os.environ.get("DISABLE_ISTIO_SIDECAR") == "true"
 secret_name_s3_accesskey = os.environ.get("SECRET_NAME_S3_ACCESSKEY")
 secret_name_s3_secretkey = os.environ.get("SECRET_NAME_S3_SECRETKEY")
 external_secret_role_arn = os.environ.get("EXTERNAL_SECRET_ROLE_ARN")
+external_secret_backend_type = os.environ.get("EXTERNAL_SECRET_BACKEND_TYPE")
 
 
 class Controller(BaseHTTPRequestHandler):
@@ -226,7 +227,7 @@ class Controller(BaseHTTPRequestHandler):
                     "namespace": namespace,
                 },
                 "spec": {
-                    "backendType": "secretsManager",
+                    "backendType": external_secret_backend_type,
                     "roleArn": external_secret_role_arn,
                     "data": [
                         {

--- a/distribution/kubeflow/pipelines/base/resources/rds-secret.yaml
+++ b/distribution/kubeflow/pipelines/base/resources/rds-secret.yaml
@@ -4,7 +4,7 @@ metadata:
   name: pipelines-rds-secret
   namespace: kubeflow
 spec:
-  backendType: secretsManager
+  backendType: <<__external_secrets.backend_type__>>
   roleArn: <<__role_arn.external_secrets.kubeflow__>>
   data:
   - key: <<__external_secret_name.kubeflow.rds_username__>>

--- a/distribution/kubeflow/pipelines/base/resources/s3-secret.yaml
+++ b/distribution/kubeflow/pipelines/base/resources/s3-secret.yaml
@@ -4,7 +4,7 @@ metadata:
   name: pipelines-s3-secret
   namespace: kubeflow
 spec:
-  backendType: secretsManager
+  backendType: <<__external_secrets.backend_type__>>
   roleArn: <<__role_arn.external_secrets.kubeflow__>>
   data:
   - key: <<__external_secret_name.kubeflow.s3_accesskey__>>

--- a/distribution/mlflow/secret.yaml
+++ b/distribution/mlflow/secret.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mlflow-secret
   namespace: mlflow
 spec:
-  backendType: secretsManager
+  backendType: <<__external_secrets.backend_type__>>
   roleArn: <<__role_arn.external_secrets.mlflow__>>
   data:
   - key: <<__external_secret_name.mlflow.rds_username__>>

--- a/distribution/oidc-auth/base/oauth2-proxy-secret.yaml
+++ b/distribution/oidc-auth/base/oauth2-proxy-secret.yaml
@@ -4,7 +4,7 @@ metadata:
   name: oauth2-proxy
   namespace: auth
 spec:
-  backendType: secretsManager
+  backendType: <<__external_secrets.backend_type__>>
   roleArn: <<__role_arn.external_secrets.auth__>>
   data:
   - key: <<__external_secret_name.auth.oidc_client_id__>>

--- a/examples/setup.conf
+++ b/examples/setup.conf
@@ -69,3 +69,4 @@
 <<__oidc.scope__>>=openid profile email
 <<__oidc.user_id_claim__>>=email
 <<__enable_registration_flow__>>="true"
+<<__external_secrets.backend_type__>>=secretsManager


### PR DESCRIPTION
Add support for SSM backend type for ExternalSecrets by adding a new placeholder value. It defaults the value to `secretsManager` so nothing changes for existing users.