### PR TITLE
Add JWT auth to Keycloak

### DIFF
--- a/distribution/oidc-auth/overlays/keycloak/oauth2-proxy-patch.yaml
+++ b/distribution/oidc-auth/overlays/keycloak/oauth2-proxy-patch.yaml
@@ -57,3 +57,9 @@ spec:
         value: profile
       - name: extraArgs.scope
         value: openid
+      - name: extraArgs.extra-jwt-issuers
+        value: 'https://<<__subdomain_auth__>>.<<__domain__>>/auth/realms/kubeflow=account'
+      - name: extraArgs.skip-jwt-bearer-tokens
+        value: <<__enable_jwt__auth>>
+      - name: extraArgs.oidc-issuer-url
+        value: 'https://<<__subdomain_auth__>>.<<__domain__>>/auth/realms/kubeflow'

--- a/examples/setup.conf
+++ b/examples/setup.conf
@@ -73,3 +73,4 @@
 <<__oidc.user_id_claim__>>=email
 <<__enable_registration_flow__>>="true"
 <<__external_secrets.backend_type__>>=secretsManager
+<<__enable_jwt__auth>>="false"


### PR DESCRIPTION
Hello,

I'm creating this PR related to my Issue #201.
If the value of <<__enable_jwt__auth>>=True the oauth2-proxy will authenticate requests with the bearer token instead of the oauth2_proxy cookie, to enable m2m authentication. 
To make this happen you need to create a new client in Keycloak and enable direct auth.
Any Suggestions or doubts? I'm happy to hear your sights. @karlschriek @DavidSpek 