### PR TITLE
Fix external-secrets error by updating cluster role

### DIFF
--- a/distribution/external-secrets/base/cluster-role.yaml
+++ b/distribution/external-secrets/base/cluster-role.yaml
@@ -7,7 +7,7 @@ metadata:
 rules:
 - apiGroups: ['']
   resources: [secrets]
-  verbs: [create, update]
+  verbs: [get, create, update]
 - apiGroups: ['']
   resources: [namespaces]
   verbs: [get, watch, list]


### PR DESCRIPTION
## Issue
The `external-secrets` controller fails to read the `git-repo-secret` due to a recent update (likely 8.x). It worked fine in 7.x. It now throws a 403 error and when you turn on debug logging it shows the following:
```
{"level":20,"message_time":"2021-09-13T23:38:25.188Z","pid":17,"hostname":"---","msg":"updating status for argocd/git-repo-secret to: ERROR, secrets \"git-repo-secret\" is forbidden: User \"system:serviceaccount:kube-system:external-secrets\" cannot get resource \"secrets\" in API group \"\" in the namespace \"argocd\""}
```

## Fix
Update the RBAC to match the RBAC generated using the [official installation instructions](https://github.com/external-secrets/kubernetes-external-secrets#install-with-kubectl). This adds 'get' for secrets resources.

