### PR TITLE
Fix MPI operator error by syncing image/manifest versions to v0.3.0

### DIFF
--- a/distribution/kubeflow/operators/mpi/kustomization.yaml
+++ b/distribution/kubeflow/operators/mpi/kustomization.yaml
@@ -2,10 +2,10 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- github.com/kubeflow/mpi-operator/manifests/overlays/kubeflow?ref=424088cef4358e1c8566677704924ddab657e8e8
+- github.com/kubeflow/mpi-operator/manifests/overlays/kubeflow?ref=db6930dcd509b1d97a47bcccd1bcb1da5eaea712 # tag=v0.3.0
 
 images:
 - name: mpioperator/mpi-operator
   newName: mpioperator/mpi-operator
-  newTag: latest
-  # digest: sha256:547b161ee16991a49aca90cd2b1048a2d3dbc4af42f4b9d5947a4b76c618dad4
+  newTag: 0.3.0
+  # digest: sha256:3ccfa8d8b7bf97836b291f5cadb39afec4b3612acddb4a5f81ecccdfaede92f9


### PR DESCRIPTION
## Issue
The MPI operator manifests are tagged to a specific commit, but the image is tagged latest. This results in the following error when starting the mpi-operator because the versions are out of sync.

```
$ kubectl logs deploy/mpi-operator -n kubeflow
flag provided but not defined: -kubectl-delivery-image
Usage of /opt/mpi-operator:
  -add_dir_header
        If true, adds the file directory to the header
...
```

## Fix
Tag the manifests and images to the latest release v0.3.0