### PR TITLE
Fix Pipelines UI S3 artifact access

### DIFF
--- a/distribution/kubeflow/pipelines/base/patches/sync_with_s3.py
+++ b/distribution/kubeflow/pipelines/base/patches/sync_with_s3.py
@@ -192,6 +192,26 @@ class Controller(BaseHTTPRequestHandler):
                                         "requests": {"cpu": "10m", "memory": "70Mi"},
                                         "limits": {"cpu": "100m", "memory": "500Mi"},
                                     },
+                                    "env": [
+                                        {
+                                            "name": "AWS_ACCESS_KEY_ID",
+                                            "valueFrom": {
+                                                "secretKeyRef": {
+                                                    "name": "pipelines-s3-secret",
+                                                    "key": "S3_ACCESSKEY"
+                                                }
+                                            }
+                                        },
+                                        {
+                                            "name": "AWS_SECRET_ACCESS_KEY",
+                                            "valueFrom": {
+                                                "secretKeyRef": {
+                                                    "name": "pipelines-s3-secret",
+                                                    "key": "S3_SECRETKEY"
+                                                }
+                                            }
+                                        }
+                                    ]
                                 }
                             ],
                             "serviceAccountName": "default-editor",

--- a/docs/iam_policies/pipelines-iam-user-s3-access.json
+++ b/docs/iam_policies/pipelines-iam-user-s3-access.json
@@ -3,10 +3,11 @@
     "Statement": [
         {
             "Effect": "Allow",
-            "Action": "s3:List*",
-            "Resource": [
-                "*"
-            ]
+            "Action": [
+                "s3:ListBucket*",
+                "s3:GetBucket*"
+            ],
+            "Resource": "arn:aws:s3:::my-pipelines-bucket"
         },
         {
             "Sid": "",


### PR DESCRIPTION
## Issue
Artifacts are not viewable from the pipelines UI:
- They don't show their value below the S3 link
- When you click on the link it throws an S3 access denied error

## Fix
- Add missing env vars to the `ml-pipeline-ui-artifact` deployment in each profile namespace. The original PR for this feature mentions that this is necessary: https://github.com/kubeflow/pipelines/pull/1278#issuecomment-591690851
- Update the S3 policy to add `GetBucket*` permissions. The policy is also tighter and scoped at the bucket resource level and doesn't need permissions at the * resource level.

## Testing
Tested on an EKS cluster running latest argoflow-aws distribution with this change and it resolved the above issues.